### PR TITLE
Replaced class_attrs with class_groups for kernel 4.14

### DIFF
--- a/hc-sro4.c
+++ b/hc-sro4.c
@@ -233,19 +233,24 @@ static const struct attribute_group *sensor_groups[] = {
 	NULL
 };
 
-static ssize_t sysfs_configure_store(struct class *class,
+static ssize_t configure_store(struct class *class,
 				struct class_attribute *attr,
 				const char *buf, size_t len);
+static CLASS_ATTR_WO(configure);
 
-static struct class_attribute hc_sro4_class_attrs[] = {
-	__ATTR(configure, 0200, NULL, sysfs_configure_store),
-	__ATTR_NULL,
+
+static struct attribute *class_hc_sro4_attrs[] = {
+	&class_attr_configure.attr,
+	NULL
 };
+ATTRIBUTE_GROUPS(class_hc_sro4);
+
+
 
 static struct class hc_sro4_class = {
 	.name = "distance-sensor",
 	.owner = THIS_MODULE,
-	.class_attrs = hc_sro4_class_attrs
+	.class_groups = class_hc_sro4_groups
 };
 
 
@@ -286,7 +291,7 @@ static int remove_sensor(struct hc_sro4 *rip_sensor)
 	return 0;
 }
 
-static ssize_t sysfs_configure_store(struct class *class,
+static ssize_t configure_store(struct class *class,
 				struct class_attribute *attr,
 				const char *buf, size_t len)
 {


### PR DESCRIPTION
Hi,
I encourted an error "_unknown field ‘class_attrs’ specified in initializer_" during compilation on Raspbian with kernel 4.14.20-v7+ 
(according to https://www.raspberrypi.org/forums/viewtopic.php?t=205802 I am not alone)

It seemed that _class_attrs_ got deprecated in newer kernel version. I used [patch from some other project](https://patchwork.kernel.org/patch/9777515/) and did analogical changes to **hc-sro4** driver.
It got compiled and seems to work on my platform. Could you test it on older version?